### PR TITLE
Add initial NIEM 1.0 - 5.2 data

### DIFF
--- a/db/backup.sh
+++ b/db/backup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pg_dump \
+  --username=postgres \
+  --password=postgres \
+  --data-only \
+  --format=plain \
+  --file=db/export.sql \
+  --disable-triggers \
+  niem-api-v2

--- a/db/load.sh
+++ b/db/load.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+psql -U postgres -d niem-api-v2 < db/niem.sql


### PR DESCRIPTION
Initial NIEM model data for versions 1.0 - 5.2 to be used with the NIEM API 2.0 Postgres database. 